### PR TITLE
:ambulance: Forward client routing in production

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/src/app/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite App</title>
+    <title>Hutello</title>
   </head>
   <body>
     <div id="root"></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "boilerplate",
       "version": "0.0.0",
       "dependencies": {
         "dotenv": "^10.0.0",

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,6 +2,8 @@ import dotenv from "dotenv";
 dotenv.config();
 
 import express from "express";
+import path from "path";
+
 const app = express();
 const { PORT = 3000 } = process.env;
 
@@ -10,6 +12,11 @@ app.use("/storybook", express.static("dist/storybook"));
 
 // Serve app production bundle
 app.use(express.static("dist/app"));
+
+// Handle client routing, return all requests to the app
+app.get("*", (_req, res) => {
+  res.sendFile(path.join(__dirname, "app/index.html"));
+});
 
 app.get("/", (_req, res) => {
   res.send("Hello World!");


### PR DESCRIPTION
On production (Heroku deployment or npm start), it's not possible to directly go to routes like /register.
This pull request fixes this issue and forwards all routes to the client.